### PR TITLE
Update spec file to use Requires(pre,preun)

### DIFF
--- a/spec
+++ b/spec
@@ -14,7 +14,7 @@ Conflicts: qmail
 Requires: supervise-scripts >= 3.2
 Requires: gnutls
 BuildRequires: gnutls-devel
-PreReq: shadow-utils
+Requires(pre,preun): shadow-utils
 
 %description
 Nullmailer is a mail transport agent designed to only relay all its


### PR DESCRIPTION
PreReq appears to be deprecated since some old version of RPM in favor of "Requires(pre,preun)".

(Closes #15)