### PR TITLE
lib/fdbuf/fdbuf.h: include <unistd.h>

### DIFF
--- a/lib/fdbuf/fdbuf.h
+++ b/lib/fdbuf/fdbuf.h
@@ -20,6 +20,7 @@
 #include "config.h"
 #include <string.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #ifdef _REENTRANT
 #include <pthread.h>


### PR DESCRIPTION
class fdobuf in lib/fdbuf/fdobuf.h makes use of uid_t and gid_t,
but these are defined in unistd.h according to POSIX.  With libc's
that adhere strictly to standards, like musl, this breaks the build.

We add <unistd.h> to fdbuf.h which is included by fdbuf.h.

Signed-off-by: Anthony G. Basile <blueness@gentoo.org>