### PR TITLE
Add ability to read SMTP AUTH password from a configuration file

### DIFF
--- a/protocols/Makefile.am
+++ b/protocols/Makefile.am
@@ -12,7 +12,7 @@ TLS_LDADD =
 endif
 
 smtp_SOURCES = smtp.cc protocol.cc $(TLS_SOURCES) protocol.h
-smtp_LDADD = ../lib/cli++/libcli++.a ../lib/libnullmailer.a $(TLS_LDADD)
+smtp_LDADD = ../lib/libnullmailer.a ../lib/cli++/libcli++.a $(TLS_LDADD)
 
 qmqp_SOURCES = qmqp.cc protocol.cc $(TLS_SOURCES) protocol.h
-qmqp_LDADD = ../lib/cli++/libcli++.a ../lib/libnullmailer.a $(TLS_LDADD)
+qmqp_LDADD = ../lib/libnullmailer.a ../lib/cli++/libcli++.a $(TLS_LDADD)

--- a/protocols/protocol.h
+++ b/protocols/protocol.h
@@ -15,6 +15,7 @@ extern void protocol_succ(const char* msg);
 #define AUTH_PLAIN 2
 extern const char* user;
 extern const char* pass;
+extern const char* passfile;
 extern int auth_method;
 extern int port;
 extern int use_ssl;

--- a/test/tests/protocols
+++ b/test/tests/protocols
@@ -33,6 +33,12 @@ do
 	echo "Testing usage error with $p (invalid integer)."
 	error 1 protocol $p -p foo localhost <testmail
 
+	echo "Testing usage error with $p (supplied both --pass & --pass-file)."
+	error 1 protocol $p --pass=password --pass-file=passwordfile localhost <testmail
+
+	echo "Testing usage error with $p (password file not read)."
+	error 1 protocol $p --pass-file=file.does.not.exist localhost <testmail
+
 	start server tcpserver 0 24680 date
 	sleep 1
 	echo "Testing protocol failure with $p."


### PR DESCRIPTION
This proposed change addresses the issue raised in https://github.com/bruceg/nullmailer/issues/24.

At present, an authentication password is passed to 'smtp' by way of a
command line option '--pass'. This makes it visible to any user who can
examine the process's status, e.g. with the 'ps' tool.

This change allows a password to be read from a nullmailer configuration
file, thereby removing the password from sight.

A new option '--pass-file' is added, whose argument is expected to be the
name of a single line file containing the password. The file should be
readable only by nullmailer.