### PR TITLE
spelling fix, as of lintian.debian.org

### DIFF
--- a/doc/nullmailer-send.8
+++ b/doc/nullmailer-send.8
@@ -42,7 +42,7 @@ the message is moved into the
 .B failed
 queue and a bounce message is generated with
 .BR nullmailer-dsn .
-If any messages remain in the queue, processing of the remaing
+If any messages remain in the queue, processing of the remaining
 messages continues with the next remote.
 When all the remotes have been tried,
 .B nullmailer-send


### PR DESCRIPTION
patch for spelling, as mentioned on
https://lintian.debian.org/full/nick@leverton.org.html#nullmailer_1_x3a1.13-1
