### PR TITLE
autogen.sh: test and create phony ChangeLog for automake to succeed

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 aclocal -I .
 autoheader
+# automake needs a file named "ChangeLog"
+if ! test -f "ChangeLog"; then
+echo "INFO: creating phony ChangeLog for automake to succeed";
+touch "ChangeLog";
+fi
 automake --add-missing
 autoconf


### PR DESCRIPTION
In the recent added autogen.sh: automake needs a file called ChangeLog to be present in the root

/Uffe
