### PR TITLE
Implement TLS anonymous authentication in smtp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,8 @@ AM_CONDITIONAL(TLS, $tls)
 if $tls; then
   AC_CHECK_LIB(gnutls, gnutls_certificate_set_verify_function,
    [AC_DEFINE(HAVE_GNUTLS_SET_VERIFY_FUNCTION, 1, [libgnutls has gnutls_certificate_set_verify_function])])
+  AC_CHECK_LIB(gnutls, gnutls_priority_set_direct,
+   [AC_DEFINE(HAVE_GNUTLS_PRIORITY_SET_DIRECT, 1, [libgnutls has gnutls_priority_set_direct])])
 fi
 
 AC_CONFIG_FILES([Makefile doc/Makefile lib/Makefile lib/cli++/Makefile lib/fdbuf/Makefile lib/mystring/Makefile protocols/Makefile src/Makefile test/Makefile])

--- a/doc/nullmailer-send.8
+++ b/doc/nullmailer-send.8
@@ -173,6 +173,13 @@ Specify that TLS X.509 files above are in DER format instead of PEM.
 .B insecure
 Don't abort a TLS connection if the server certificate fails validation.
 Use this only if you know the server uses an invalid certificate.
+.TP
+.B tls-anon-auth
+Use TLS anonymous authentication - replacing certificate authentication.
+This means no external certificates or passwords are needed to set up the connection.
+With this option your connection is vulnerable to man-in-the-middle (active or redirection) attacks.
+However, the data are integrity protected and encrypted from passive eavesdroppers.
+This option must be used with the insecure option - to acknowledge that you know what you are doing.
 .SH FILES
 .TP
 .B /var/spool/nullmailer/failed
@@ -194,3 +201,4 @@ nullmailer-dsn(1),
 nullmailer-inject(1),
 nullmailer-queue(8),
 mailq(1)
+http://www.postfix.org/TLS_README.html on how to setup a certificate-less Postfix SMTP server

--- a/protocols/protocol.cc
+++ b/protocols/protocol.cc
@@ -73,6 +73,8 @@ cli_option cli_options[] = {
     "X.509 files are in DER format", "PEM format" },
   { 0, "insecure", cli_option::flag, true, &tls_insecure,
     "Don't abort if server certificate fails validation", 0 },
+  { 0, "tls-anon-auth", cli_option::flag, true, &tls_anon_auth,
+    "Use TLS anonymous authentication - needs --insecure option", 0 },
 #endif
   {0, 0, cli_option::flag, 0, 0, 0, 0}
 };
@@ -151,4 +153,3 @@ int cli_main(int, char*[])
     plain_send(in, fd);
   return 0;
 }
-

--- a/protocols/protocol.h
+++ b/protocols/protocol.h
@@ -19,13 +19,13 @@ extern int auth_method;
 extern int port;
 extern int use_tls;
 extern int use_starttls;
-extern int tls_insecure;
 
 extern void protocol_prep(fdibuf& in);
 extern void protocol_send(fdibuf& in, fdibuf& netin, fdobuf& netout);
 extern void protocol_starttls(fdibuf& netin, fdobuf& netout);
 
 extern int tls_insecure;
+extern int tls_anon_auth;
 extern const char* tls_x509certfile;
 extern const char* tls_x509keyfile;
 extern const char* tls_x509cafile;


### PR DESCRIPTION
Hi,

The following patch will add the ability to do TLS anonymous authentication into nullmailer

NOTE: the HAVE_GNUTLS_PRIORITY_FUNCS was never working - as it did not appear in the configure.ac

TLS anonymous authentication is useful for non-public MX hosts.
With this option data integrity is protected and encrypted from passive eavesdroppers - but your connection is vulnerable to man-in-the-middle (active or redirection) attacks.
Postfix supports configurations with no server certificates that use only the anonymous ciphers.

TLS anonymous authentication is described here (postfix) - look for "aNULL": 
http://www.postfix.org/TLS_README.html#server_cipher
http://www.postfix.org/TLS_README.html#client_cipher





