### PR TITLE
fix build on illumos

### DIFF
--- a/lib/forkexec.h
+++ b/lib/forkexec.h
@@ -3,6 +3,7 @@
 
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <signal.h>
 #include "mystring/mystring.h"
 #include "autoclose.h"
 #include "configio.h"

--- a/lib/tcpconnect.cc
+++ b/lib/tcpconnect.cc
@@ -33,19 +33,23 @@
 
 static int err_return(int errn, int dflt)
 {
-  switch(errn) {
-  case HOST_NOT_FOUND: return -ERR_HOST_NOT_FOUND;
-  case NO_ADDRESS: return -ERR_NO_ADDRESS;
-  case NO_RECOVERY: return -ERR_GHBN_FATAL;
-  case TRY_AGAIN: return -ERR_GHBN_TEMP;
-  case EAI_AGAIN: return -ERR_GHBN_TEMP;
-  case EAI_NONAME: return -ERR_HOST_NOT_FOUND;
-  case EAI_FAIL: return -ERR_GHBN_FATAL;
-  case ECONNREFUSED: return -ERR_CONN_REFUSED;
-  case ETIMEDOUT: return -ERR_CONN_TIMEDOUT;
-  case ENETUNREACH: return -ERR_CONN_UNREACHABLE;
-  default: return -dflt;
-  }
+  if (errn == HOST_NOT_FOUND)
+    return -ERR_HOST_NOT_FOUND;
+  if (errn == NO_ADDRESS)
+    return -ERR_NO_ADDRESS;
+  if (errn == NO_RECOVERY || errn == EAI_FAIL)
+    return -ERR_GHBN_FATAL;
+  if (errn == TRY_AGAIN || errn == EAI_AGAIN)
+    return -ERR_GHBN_TEMP;
+  if (errn == EAI_NONAME)
+    return -ERR_HOST_NOT_FOUND;
+  if (errn == ECONNREFUSED)
+    return -ERR_CONN_REFUSED;
+  if (errn == ETIMEDOUT)
+    return -ERR_CONN_TIMEDOUT;
+  if (errn == ENETUNREACH)
+    return -ERR_CONN_UNREACHABLE;
+  return -dflt;
 }
 
 #ifdef HAVE_GETADDRINFO


### PR DESCRIPTION
This fixes the build on SmartOS/illumos (and maybe other plattforms).

The first error was:

```
tcpconnect.cc: In function 'int err_return(int, int)':
tcpconnect.cc:41:3: error: duplicate case value
tcpconnect.cc:40:3: error: previously used here
tcpconnect.cc:43:3: error: duplicate case value
tcpconnect.cc:38:3: error: previously used here
```

This required the change in `err_return()` because on some plattforms these defines can share the same value.

The second one was:

```
In file included from forkexec.cc:33:0:
forkexec.h: In member function 'void fork_exec::kill(int)':
forkexec.h:32:31: error: '::kill' has not been declared
```

Simply needs `signal.h`.

