### PR TITLE
Add support for RFC976 "From_ lines"

### DIFF
--- a/src/inject.cc
+++ b/src/inject.cc
@@ -342,11 +342,16 @@ bool read_header()
 {
   mystring cur_line;
   mystring whole;
+  bool first = true;
   for (;;) {
     if (!fin.getline(cur_line))
       cur_line = "";
     if(!cur_line || cur_line == "\r")
       break;
+    if(first && (cur_line.find_first_of("From ", 0) == 0 ||
+       cur_line.find_first_of(">From ", 0) == 0))
+      continue;
+    first = false;
     if(!!whole && is_continuation(cur_line)) {
       //if(!whole)
       //bad_hdr(cur_line, "First line cannot be a continuation line.");


### PR DESCRIPTION
Add support for UUCP "From_ lines". RFC976 describes these as:

```
   ... the "source path" (normally
   represented in one or more lines at the beginning of the message
   beginning either "From " or ">From ", sometimes called "From_
   lines".)
```

This fixes an issue where emails generated by cron would have their headers in the mailbody.

Example:

```
From root Mon Nov 14 23:42 UTC 2016
To: root
Subject: Cron <root@5ca32ab7-57b7-4af4-8740-69fcd29cef86> echo hi
Auto-Submitted: auto-generated
X-Mailer: cron (SunOS 5.11)
X-Cron-User: root
X-Cron-Host: 5ca32ab7-57b7-4af4-8740-69fcd29cef86
X-Cron-Job-Name: echo hi
X-Cron-Job-Type: cron
MIME-Version: 1.0
Content-Type: text/plain
Content-Length: 3

hi
```

If the first line starts with "From " or ">From " the line is skipped instead of parsing everything as body.
