### PR TITLE
Remove race conditions from tests

### DIFF
--- a/test/functions.in
+++ b/test/functions.in
@@ -20,6 +20,7 @@ exit_cleanup() {
     # Remove all temporary files on success
     if [ $? -eq 0 ]
     then
+        sleep 1
         rm -rf $tmpdir
     fi
 }

--- a/test/tests/protocols
+++ b/test/tests/protocols
@@ -66,6 +66,7 @@ do
 	echo "Testing protocol failure with $p."
 	error 11 protocol $p -p $port --host=localhost 3<testmail
 	stop server
+	sleep 1
 done
 
 rm -f testmail


### PR DESCRIPTION
Testing the qmqp protocol fails because the testing server cannot acquire the lock.  This is solved by sleeping for one second so the previous server has time to exit and clear the lock. Also, sleep elsewhere before removing temporary directories.