### PR TITLE
lib/argparse: fix parsing of shell-like quoting structures when encountered mid-string.

### DIFF
--- a/lib/argparse.cc
+++ b/lib/argparse.cc
@@ -10,7 +10,7 @@ static const char* parse_arg(mystring& arg, const char* start, const char* end)
       arg.append(start, ptr - start);
       for (start = ++ptr; ptr < end && *ptr != '\''; ++ptr) ;
       arg.append(start, ptr - start);
-      start = ++ptr;
+      start = ptr + 1;
       continue;
     case '"':
       arg.append(start, ptr - start);
@@ -23,7 +23,7 @@ static const char* parse_arg(mystring& arg, const char* start, const char* end)
 	}
       }
       arg.append(start, ptr - start);
-      start = ++ptr;
+      start = ptr + 1;
       continue;
     case '\\':
       arg.append(start, ptr - start);
@@ -33,7 +33,8 @@ static const char* parse_arg(mystring& arg, const char* start, const char* end)
       continue;
     }
   }
-  arg.append(start, ptr - start);
+  if ((ptr - start) > 0)
+    arg.append(start, ptr - start);
   return ptr;
 }
 

--- a/test/argparse-test.cc
+++ b/test/argparse-test.cc
@@ -42,6 +42,8 @@ int main()
   TEST("\"one two\"", 1, "one two");		     // Double quoted
   TEST(" one \"two\"three four", 3, "one", "twothree", "four"); // Mixed quoted and unquoted
   TEST("\"one\\\" two\"", 1, "one\" two");			// Double quoted with escaped quote
+  TEST("one='two three' four", 2, "one=two three", "four");	// Single quotes within an arg with multiple args
+  TEST("one=\"two three\" four", 2, "one=two three", "four");	// Double quotes within an arg with multiple args
 
   fout << itoa(count) << " tests run, ";
   fout << itoa(failed) << " failed." << endl;


### PR DESCRIPTION
Fixes: https://github.com/bruceg/nullmailer/issues/45