### PR TITLE
Fix failing protocol test when building with TLS

### DIFF
--- a/lib/tcpconnect.cc
+++ b/lib/tcpconnect.cc
@@ -95,6 +95,7 @@ int tcpconnect(const char* hostname, int port, const char* source)
       return err;
   }
   int s = -1;
+  errno = 0;
   err = ERR_CONN_FAILED;
   struct addrinfo* orig_res = res;
 


### PR DESCRIPTION
When building from source after configuring with '--enable-tls', the protocol test for smtp ('make check') fails with an unexpected retval (5 vs. 10). The error probably occurs only when getaddrinfo() is available. A earlier stray errno may survive past a series of conditionals, and should be cleared.

David Bremner previously raised this issue on the untroubled mailing list.

Sorry about all the noise as I navigate the new world of GitHub pull requests. Thank you!
