### PR TITLE
lib/itoa: fix array subscript below bounds warning

### DIFF
--- a/lib/itoa.cc
+++ b/lib/itoa.cc
@@ -15,7 +15,7 @@ const char *itoa(long v, int digits)
     v /= 10;
     --digits;
   } while(v != 0);
-  while(digits > 0 && ptr > buf-1)
+  while(digits > 0 && ptr >= buf)
     *--ptr = '0', --digits;
   if(neg)
     *--ptr = '-';


### PR DESCRIPTION
Trivial fix for this warning seen with gcc-8.2:
```
itoa.cc: In function 'const char* itoa(long int, int)':
itoa.cc:18:32: warning: array subscript -1 is below array bounds of 'char [64]' [-Warray-bounds]
   while(digits > 0 && ptr > buf-1)
                             ~~~^~
```