### PR TITLE
note filesystem constraints for nullmailer directories

### DIFF
--- a/doc/nullmailer-queue.8
+++ b/doc/nullmailer-queue.8
@@ -45,6 +45,17 @@ The directory in which messages are formed temporarily.
 A pipe used to trigger
 .BR nullmailer-send
 to immediately start sending the message from the queue.
+.PP
+Note that due to
+.B nullmailer-queue
+using hard links to manage emails both
+.I /var/spool/nullmailer/queue
+and
+.I /var/spool/nullmailer/tmp
+.I have
+to reside on the
+.I same
+filesystem.
 .SH SEE ALSO
 nullmailer-inject(1),
 nullmailer-send(8)


### PR DESCRIPTION
both /var/spool/nullmailer/tmp and /var/spool/nullmailer/queue have to reside on the same filesystem