### PR TITLE
Fix memory management issues causing failures under the scudo allocator

### DIFF
--- a/lib/fdbuf/fdbuf.cc
+++ b/lib/fdbuf/fdbuf.cc
@@ -57,7 +57,7 @@ fdbuf::~fdbuf()
 #ifdef _REENTRANT
   pthread_mutex_destroy(&mutex);
 #endif
-  delete buf;
+  delete[] buf;
 }
 
 bool fdbuf::error() const

--- a/lib/mystring/rep.cc
+++ b/lib/mystring/rep.cc
@@ -152,6 +152,6 @@ void mystringrep::detach()
   --references;
   if(!references) {
     trace("deleting this");
-    delete this;
+    delete[] (char*)this;
   }
 }


### PR DESCRIPTION
In a few places in the nullmailer codebase `delete` is used to free memory allocated via `new[]`, which is invalid C++. Most memory allocators don't care, but some hardened allocators (e.g. Scudo) will abort in such conditions.

Tested that nullmailer runs under the scudo allocator using this patch.