### PR TITLE
Add "AUTH EXTERNAL" option for certificate authentication

### DIFF
--- a/doc/nullmailer-send.8
+++ b/doc/nullmailer-send.8
@@ -137,6 +137,9 @@ Set the source address for connections to the remote host.
 .B auth-login
 Force SMTP "AUTH LOGIN" mode instead of auto-detecting.
 .TP
+.B auth-external
+Use SMTP "AUTH EXTERNAL" for TLS client certificate authentication.
+.TP
 .B tls
 Connect using TLS.
 This will automatically switch the default port to

--- a/protocols/protocol.cc
+++ b/protocols/protocol.cc
@@ -55,6 +55,8 @@ cli_option cli_options[] = {
   { 0, "source", cli_option::string, 0, &source,
     "Source address for connections", 0 },
 #ifdef HAVE_TLS
+  { 0, "auth-external", cli_option::flag, AUTH_EXTERNAL, &auth_method,
+    "Use AUTH EXTERNAL for certificate based authentication", 0 },
   { 0, "tls", cli_option::flag, 1, &use_tls,
     "Connect using TLS (on an alternate port by default)", 0 },
   { 0, "ssl", cli_option::flag, 1, &use_tls,

--- a/protocols/protocol.h
+++ b/protocols/protocol.h
@@ -13,6 +13,7 @@ extern void protocol_succ(const char* msg);
 #define AUTH_DETECT 0
 #define AUTH_LOGIN 1
 #define AUTH_PLAIN 2
+#define AUTH_EXTERNAL 3
 extern const char* user;
 extern const char* pass;
 extern int auth_method;

--- a/protocols/smtp.cc
+++ b/protocols/smtp.cc
@@ -231,7 +231,14 @@ void protocol_send(fdibuf& in, fdibuf& netin, fdobuf& netout)
   if (!did_starttls)
     conn.docmd("", 200);
 
-  if (user != 0 && pass != 0) {
+  if (auth_method == AUTH_EXTERNAL) {
+    conn.dohelo(true);
+    if (conn.hascap("AUTH", "EXTERNAL"))
+      conn.docmd("AUTH EXTERNAL =", 200, ERR_AUTH_FAILED);
+    else
+      protocol_fail(ERR_MSG_TEMPFAIL, "Server does not advertise certificate authentication");
+  }
+  else if (user != 0 && pass != 0) {
     conn.dohelo(true);
     if (auth_method == AUTH_LOGIN)
       conn.auth_login();


### PR DESCRIPTION
This allows nullmailer to authenticate with a sendmail server using the TLS client certiticate.

Tested agains the Debian bullseye sendmail 8.15.2  package.

Obfuscated log from the sendmail server:

```
sm-mta[1536129]: NOQUEUE: connect from [IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073]                                                                                                                                        
sm-mta[1536129]: AUTH warning: no mechanisms                                                                                                                                                                               
sm-mta[1536129]: 223Ha7ak1536129: --- 220 foo.example.com ESMTP Sendmail 8.15.2/8.15.2; Thu, 3 Mar 2022 17:36:07 GMT                                                                                                         
sm-mta[1536129]: 223Ha7ak1536129: <-- EHLO bar.example.com                                                                                                                                                                  
sm-mta[1536129]: 223Ha7ak1536129: --- 250-foo.example.com Hello [IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073], pleased to meet you                                                                                            
sm-mta[1536129]: 223Ha7ak1536129: --- 250-ENHANCEDSTATUSCODES                                                                                                                                                              
sm-mta[1536129]: 223Ha7ak1536129: --- 250-PIPELINING                                                                                                                                                                       
sm-mta[1536129]: 223Ha7ak1536129: --- 250-EXPN                                                                                                                                                                             
sm-mta[1536129]: 223Ha7ak1536129: --- 250-VERB                                                                                                                                                                             
sm-mta[1536129]: 223Ha7ak1536129: --- 250-8BITMIME                                                                                                                                                                         
sm-mta[1536129]: 223Ha7ak1536129: --- 250-SIZE                                                                                                                                                                             
sm-mta[1536129]: 223Ha7ak1536129: --- 250-STARTTLS                                                                                                                                                                         
sm-mta[1536129]: 223Ha7ak1536129: --- 250-DELIVERBY                                                                                                                                                                        
sm-mta[1536129]: 223Ha7ak1536129: --- 250 HELP                                                                                                                                                                             
sm-mta[1536129]: 223Ha7ak1536129: <-- STARTTLS                                                                                                                                                                             
sm-mta[1536129]: 223Ha7ak1536129: --- 220 2.0.0 Ready to start TLS                                                                                                                                                         
sm-mta[1536129]: STARTTLS=server, get_verify: 0 get_peer: 0x55914c4f4050                                                                                                                                                   
sm-mta[1536129]: STARTTLS=server, relay=[IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073], version=TLSv1.3, verify=OK, cipher=TLS_AES_256_GCM_SHA384, bits=256/256                                                              
sm-mta[1536129]: STARTTLS=server, cert-subject=/CN=bar.example.com, cert-issuer=/C=US/O=Let's+20Encrypt/CN=R3, verifymsg=ok                                                                                                 
sm-mta[1536129]: AUTH: available mech=EXTERNAL, allowed mech=EXTERNAL GSSAPI KERBEROS_V4 DIGEST-MD5 CRAM-MD5                                                                                                               
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7ak1536129: <-- EHLO bar.example.com                                                                                                                                                                  
sm-mta[1536129]: 223Ha7al1536129: --- 250-foo.example.com Hello [IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073], pleased to meet you                                                                                            
sm-mta[1536129]: 223Ha7al1536129: --- 250-ENHANCEDSTATUSCODES                                                                                                                                                              
sm-mta[1536129]: 223Ha7al1536129: --- 250-PIPELINING                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: --- 250-EXPN                                                                                                                                                                             
sm-mta[1536129]: 223Ha7al1536129: --- 250-VERB                                                                                                                                                                             
sm-mta[1536129]: 223Ha7al1536129: --- 250-8BITMIME                                                                                                                                                                         
sm-mta[1536129]: 223Ha7al1536129: --- 250-SIZE                                                                                                                                                                             
sm-mta[1536129]: 223Ha7al1536129: --- 250-AUTH EXTERNAL                                                                                                                                                                    
sm-mta[1536129]: 223Ha7al1536129: --- 250-DELIVERBY                                                                                                                                                                        
sm-mta[1536129]: 223Ha7al1536129: --- 250 HELP                                                                                                                                                                             
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: <-- AUTH EXTERNAL =                                                                                                                                                                      
sm-mta[1536129]: 223Ha7al1536129: --- 235 2.0.0 OK Authenticated                                                                                                                                                           
sm-mta[1536129]: AUTH=server, relay=[IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073], authid=/CN+3Dbar.example.com, mech=EXTERNAL, bits=0                                                                                       
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: <-- MAIL FROM:<bjorn@bar.example.com>                                                                                                                                                     
milter-greylist[1486955]: User /CN+3Dbar.example.com authenticated, bypassing greylisting                                                                                                                                   
sm-mta[1536129]: 223Ha7al1536129: --- 250 2.1.0 <bjorn@bar.example.com>... Sender ok                                                                                                                                        
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: <-- RCPT TO:<bjorn+bar@example.com>                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: --- 250 2.1.5 <bjorn+bar@example.com>... Recipient ok                                                                                                                                     
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: <-- DATA                                                                                                                                                                                 
sm-mta[1536129]: 223Ha7al1536129: --- 354 Enter mail, end with "." on a line by itself                                                                                                                                     
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7al1536129: from=<bjorn@bar.example.com>, size=511, class=0, nrcpts=1, msgid=<1646328962.007063.1857517.nullmailer@bar.example.com>, proto=ESMTPSA, daemon=MSP-v6, relay=[IPv6:2001:db8:100:2500:15b7:e53a:fe0c:c073]
sm-mta[1536129]: 223Ha7al1536129: --- 250 2.0.0 223Ha7al1536129 Message accepted for delivery                                                                                                                              
sm-mta[1536129]: STARTTLS=read, info: fds=8/4, err=2                                                                                                                                                                       
sm-mta[1536129]: 223Ha7am1536129: <-- QUIT                                                                                                                                                                                 
sm-mta[1536129]: 223Ha7am1536129: --- 221 2.0.0 foo.example.com closing connection                                                                                                                                           

```