### PR TITLE
RPM spec updates

### DIFF
--- a/spec
+++ b/spec
@@ -49,7 +49,7 @@ PATH="/sbin:/usr/sbin:$PATH" export PATH
 if [ "$1" = 1 ]; then
 	# pre-install instructions
 	grep ^nullmail: /etc/group >/dev/null || groupadd -r nullmail
-	grep ^nullmail: /etc/passwd >/dev/null || useradd -d /var/lock/svc/nullmailer -g nullmail -M -r -s /bin/true nullmail
+	grep ^nullmail: /etc/passwd >/dev/null || useradd -d /var/spool/nullmailer -g nullmail -M -r -s /bin/false nullmail
 fi
 
 %post

--- a/spec
+++ b/spec
@@ -81,6 +81,7 @@ fi
 %doc AUTHORS BUGS ChangeLog COPYING INSTALL NEWS README TODO doc/DIAGRAM
 %dir /etc/nullmailer
 %attr(04711,nullmail,nullmail) /usr/bin/mailq
+/usr/bin/nullmailer-dsn
 /usr/bin/nullmailer-inject
 /usr/bin/nullmailer-smtpd
 /usr/lib/sendmail

--- a/spec
+++ b/spec
@@ -37,7 +37,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/lib
 mkdir -p $RPM_BUILD_ROOT/var/service/nullmailer/log
 mkdir -p $RPM_BUILD_ROOT/var/log/nullmailer
 
-make DESTDIR=$RPM_BUILD_ROOT install-strip
+make DESTDIR=$RPM_BUILD_ROOT install
 ln -s ../sbin/sendmail $RPM_BUILD_ROOT/usr/lib/sendmail
 install scripts/nullmailer.run $RPM_BUILD_ROOT/var/service/nullmailer/run
 install scripts/nullmailer-log.run $RPM_BUILD_ROOT/var/service/nullmailer/log/run

--- a/spec
+++ b/spec
@@ -41,6 +41,7 @@ make DESTDIR=$RPM_BUILD_ROOT install
 ln -s ../sbin/sendmail $RPM_BUILD_ROOT/usr/lib/sendmail
 install scripts/nullmailer.run $RPM_BUILD_ROOT/var/service/nullmailer/run
 install scripts/nullmailer-log.run $RPM_BUILD_ROOT/var/service/nullmailer/log/run
+install scripts/nullmailer.service $RPM_BUILD_ROOT/usr/lib/systemd/system
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -85,6 +86,7 @@ fi
 /usr/bin/nullmailer-inject
 /usr/bin/nullmailer-smtpd
 /usr/lib/sendmail
+/usr/lib/systemd/system/nullmailer.service
 %dir /usr/libexec/nullmailer
 /usr/libexec/nullmailer/*
 %{_mandir}/*/*


### PR DESCRIPTION
The RPM spec doesn't seem to be up to date and it fails to build packages at the moment.

The updated spec file:
- Uses the `install` Makefile rule instead of `install-strip`, which isn't working properly
- Adds `nullmailer-dsn` to the package
- Replaces supervise-scripts with systemd
- No longer removes the nullmail user and group on uninstall, so that leftovers can't be accessed by random stuff that gets installed later