### PR TITLE
Use the “mail” syslog facility in the journal

### DIFF
--- a/scripts/nullmailer.service
+++ b/scripts/nullmailer.service
@@ -12,6 +12,7 @@ ExecStart=/usr/sbin/nullmailer-send
 User=nullmail
 Group=nullmail
 Restart=always
+SyslogFacility=mail
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When running under systemd, what’s done with text the program prints to stdout/stderr depends on the `StandardOutput` and `StandardError` directives in the unit file. Those are unset in this unit file (which is probably appropriate), which means they inherit defaults from a global config file. If unset in that config file, in turn, the default is to write the messages to the system journal. When that is done, the journal entries are automatically given syslog-style metadata, i.e. an identifier, facility code, and priority level. If unspecified, the facility code is set to “daemon”; however, since nullmailer is in the business of handling e-mail, “mail” is a better choice out of the available set.